### PR TITLE
add option to select different reveal.js theme

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,27 @@
         "key": "ctrl+alt+r",
         "when": "editorLangId == markdown"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Reveal.js Live Preview",
+      "properties": {
+        "revealjsLivePreview.theme": {
+          "type": "string",
+          "default": "white",
+          "enum": [
+            "black",
+            "white",
+            "league",
+            "moon",
+            "night",
+            "serif",
+            "simple",
+            "solarized"
+          ],
+          "description": "Select the theme for Reveal.js slides."
+        }
+      }
+    }
   },
   "scripts": {
     "lint": "eslint --config eslint.config.js",


### PR DESCRIPTION
### Description
Add option to select various reveal.js themes.

Steps:
1. Open settings `Ctrl + ,`
2. Search for `Reveal.js Live Preview Theme`
3. Choose your prefered theme from dropdown
4. Restart preview `Ctrl + Alt + R`